### PR TITLE
cargocms-netcore2-element to 0.8.12

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.1.15
 - name: cargocms-netcore2-element
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.8.11
+  version: 0.8.12
 - alias: expose
   name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io


### PR DESCRIPTION
Promote cargocms-netcore2-element to version 0.8.12