### PR TITLE
cargocms-netcore2-element to 0.9.23

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -3,13 +3,13 @@ dependencies:
   repository: https://chartmuseum.jx.k8s.trunksys.com
   version: 0.2.9
 - name: cargocms-netcore2-element
-  repository: https://chartmuseum.jx.k8s.trunksys.com
-  version: 0.9.21
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.9.23
 - alias: expose
   name: exposecontroller
-  repository: http://chartmuseum.jenkins-x.io 
+  repository: http://chartmuseum.jenkins-x.io
   version: 2.3.58
 - alias: cleanup
   name: exposecontroller
-  repository: http://chartmuseum.jenkins-x.io 
+  repository: http://chartmuseum.jenkins-x.io
   version: 2.3.58


### PR DESCRIPTION
Promote cargocms-netcore2-element to version 0.9.23