### PR TITLE
cargocms-netcore2-element to 1.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -3,8 +3,8 @@ dependencies:
   repository: https://chartmuseum.jx.k8s.trunksys.com
   version: 0.2.16
 - name: cargocms-netcore2-element
-  repository: https://chartmuseum.jx.k8s.trunksys.com
-  version: 1.0.3
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.4
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
Promote cargocms-netcore2-element to version 1.0.4