### PR TITLE
cargocms-netcore2-element to 1.0.49

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.2.25
 - name: cargocms-netcore2-element
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.48
+  version: 1.0.49
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
Promote cargocms-netcore2-element to version 1.0.49