### PR TITLE
cargocms-netcore2-element to 1.0.69

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.2.28
 - name: cargocms-netcore2-element
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.68
+  version: 1.0.69
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
Promote cargocms-netcore2-element to version 1.0.69